### PR TITLE
Add option in settings to manually specify php path

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,6 +1,21 @@
+{CompositeDisposable} = require 'atom'
 provider = require './provider'
 
 module.exports =
-  activate: -> provider.loadCompletions()
+  config:
+    executablePath:
+      type: 'string'
+      title: 'PHP Executable Path'
+      default: 'php' # Let OS's $PATH handle the rest
+
+  activate: ->
+    @subscriptions = new CompositeDisposable
+    @subscriptions.add atom.config.observe 'autocomplete-php.executablePath',
+      (executablePath) ->
+        provider.executablePath = executablePath
+    provider.loadCompletions()
+
+  deactivate: ->
+    @subscriptions.dispose()
 
   getProvider: -> provider

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -3,6 +3,8 @@ fs = require 'fs'
 path = require 'path'
 
 module.exports =
+  executablePath: 'php'
+
   # This will work on JavaScript and CoffeeScript files, but not in js comments.
   selector: '.source.php'
   disableForSelector: '.source.php .comment'
@@ -33,7 +35,7 @@ module.exports =
     @compileData = ''
     phpEx = 'get_user_all.php'
 
-    proc = exec.spawn 'php', [__dirname + '/php/' + phpEx]
+    proc = exec.spawn this.executablePath, [__dirname + '/php/' + phpEx]
 
     proc.stdin.write(editor.getText())
     proc.stdin.end()


### PR DESCRIPTION
Fix for #20, #19, #18, #11.

After update settings button will be show up:
![capture](https://cloud.githubusercontent.com/assets/9192409/9233589/2d39461a-4134-11e5-99f3-1d6eced35ba5.PNG)

And option to manually enter path of `php`:
![capture](https://cloud.githubusercontent.com/assets/9192409/9233608/54823eb6-4134-11e5-92f6-4c4b678b42a1.PNG)
