### PR TITLE
Magic Methods

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -148,8 +148,8 @@ module.exports =
     for func in @funtions.functions when func.text.toLowerCase().indexOf(lowerCasePrefix) is 0
       completions.push(@buildCompletion(func))
 
-    for func in @methods.functions when func.text.toLowerCase().indexOf(lowerCasePrefix) is 0
-      completions.push(@buildCompletion(func))
+    for methods in @methods.methods when methods.text.toLowerCase().indexOf(lowerCasePrefix) is 0
+      completions.push(@buildCompletion(methods))
 
     completions
 
@@ -170,8 +170,8 @@ module.exports =
     for func in @funtions.functions when func.text.toLowerCase().indexOf(lowerCasePrefix) is 0
       completions.push(@buildCompletion(func))
 
-    for func in @methods.functions when func.text.toLowerCase().indexOf(lowerCasePrefix) is 0
-      completions.push(@buildCompletion(func))
+    for methods in @methods.methods when methods.text.toLowerCase().indexOf(lowerCasePrefix) is 0
+      completions.push(@buildCompletion(methods))
 
     completions
 

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -28,6 +28,11 @@ module.exports =
       @funtions = JSON.parse(content) unless error?
       return
 
+    @methods = {}
+    fs.readFile path.resolve(__dirname, '..', 'methods.json'), (error, content) =>
+      @methods = JSON.parse(content) unless error?
+      return
+
   execute: ({editor}, force = false) ->
     if !force
       return if @userVars? and @lastPath == editor.getPath()
@@ -143,6 +148,9 @@ module.exports =
     for func in @funtions.functions when func.text.toLowerCase().indexOf(lowerCasePrefix) is 0
       completions.push(@buildCompletion(func))
 
+    for func in @methods.functions when func.text.toLowerCase().indexOf(lowerCasePrefix) is 0
+      completions.push(@buildCompletion(func))
+
     completions
 
   getCompletions: ({editor, prefix}) ->
@@ -160,6 +168,9 @@ module.exports =
         completions.push(@buildCompletion(userFunc))
 
     for func in @funtions.functions when func.text.toLowerCase().indexOf(lowerCasePrefix) is 0
+      completions.push(@buildCompletion(func))
+
+    for func in @methods.functions when func.text.toLowerCase().indexOf(lowerCasePrefix) is 0
       completions.push(@buildCompletion(func))
 
     completions

--- a/methods.json
+++ b/methods.json
@@ -1,5 +1,5 @@
 {
-  "functions": [
+  "methods": [
     {
       "text": "__construct",
       "type": "method",

--- a/methods.json
+++ b/methods.json
@@ -1,0 +1,16 @@
+{
+  "functions": [
+    {
+      "text": "__construct",
+      "type": "method",
+      "descriptionMoreURL": "http://php.net/manual/en/language.oop5.decon.php#object.construct",
+      "snippet": "__construct()${1}"
+    },
+    {
+      "text": "__destruct",
+      "type": "method",
+      "descriptionMoreURL": "http://php.net/manual/en/language.oop5.decon.php#object.destruct",
+      "snippet": "__destruct()${1}"
+    }
+  ]
+}

--- a/methods.json
+++ b/methods.json
@@ -11,6 +11,84 @@
       "type": "method",
       "descriptionMoreURL": "http://php.net/manual/en/language.oop5.decon.php#object.destruct",
       "snippet": "__destruct()${1}"
+    },
+    {
+      "text": "__call",
+      "type": "method",
+      "descriptionMoreURL": "http://php.net/manual/en/language.oop5.overloading.php#object.call",
+      "snippet": "__call()${1}"
+    },
+    {
+      "text": "__callStatic",
+      "type": "method",
+      "descriptionMoreURL": "http://php.net/manual/en/language.oop5.overloading.php#object.callstatic",
+      "snippet": "__callStatic()${1}"
+    },
+    {
+      "text": "__get",
+      "type": "method",
+      "descriptionMoreURL": "http://php.net/manual/en/language.oop5.overloading.php#object.get",
+      "snippet": "__get()${1}"
+    },
+    {
+      "text": "__set",
+      "type": "method",
+      "descriptionMoreURL": "http://php.net/manual/en/language.oop5.overloading.php#object.set",
+      "snippet": "__set()${1}"
+    },
+    {
+      "text": "__isset",
+      "type": "method",
+      "descriptionMoreURL": "http://php.net/manual/en/language.oop5.overloading.php#object.isset",
+      "snippet": "__isset()${1}"
+    },
+    {
+      "text": "__unset",
+      "type": "method",
+      "descriptionMoreURL": "http://php.net/manual/en/language.oop5.overloading.php#object.unset",
+      "snippet": "__unset()${1}"
+    },
+    {
+      "text": "__sleep",
+      "type": "method",
+      "descriptionMoreURL": "http://php.net/manual/en/language.oop5.magic.php#object.sleep",
+      "snippet": "__sleep()${1}"
+    },
+    {
+      "text": "__wakeup",
+      "type": "method",
+      "descriptionMoreURL": "http://php.net/manual/en/language.oop5.magic.php#object.wakeup",
+      "snippet": "__wakeup()${1}"
+    },
+    {
+      "text": "__toString",
+      "type": "method",
+      "descriptionMoreURL": "http://php.net/manual/en/language.oop5.magic.php#object.tostring",
+      "snippet": "__toString()${1}"
+    },
+    {
+      "text": "__invoke",
+      "type": "method",
+      "descriptionMoreURL": "http://php.net/manual/en/language.oop5.magic.php#object.invoke",
+      "snippet": "__invoke()${1}"
+    },
+    {
+      "text": "__set_state",
+      "type": "method",
+      "descriptionMoreURL": "http://php.net/manual/en/language.oop5.magic.php#object.set-state",
+      "snippet": "__set_state()${1}"
+    },
+    {
+      "text": "__clone",
+      "type": "method",
+      "descriptionMoreURL": "http://php.net/manual/en/language.oop5.cloning.php#object.clone",
+      "snippet": "__clone()${1}"
+    },
+    {
+      "text": "__debugInfo",
+      "type": "method",
+      "descriptionMoreURL": "http://php.net/manual/en/language.oop5.magic.php#object.debuginfo",
+      "snippet": "__debugInfo()${1}"
     }
   ]
 }


### PR DESCRIPTION
Added [magic methods](http://php.net/manual/en/language.oop5.magic.php)

If this solution is acceptable then it should be easy enough to add the others via `methods.json` If not, then I'm sure we can restructure this to make it work.

Fixed some bugs that I missed in the previous commit.
Edit: I didn't know I could just leave the original pull request... my bad :anguished: